### PR TITLE
Create logger only if doesn't exist

### DIFF
--- a/plugin/src/NH/Logger.cpp
+++ b/plugin/src/NH/Logger.cpp
@@ -90,6 +90,15 @@ namespace NH {
     LoggerFactory *LoggerFactory::s_Instance = null;
 
     Logger *LoggerFactory::Create(const String &name) {
+        
+        for (auto* logger : m_Loggers)
+        {
+            if (logger->m_LoggerName == name)
+            {
+                return logger;
+            }
+        }
+        
         auto *logger = new NH::Logger(name, {
                 new NH::UnionConsoleLoggerAdapter(NH::LoggerLevel::Trace),
                 new NH::ZSpyLoggerAdapter(NH::LoggerLevel::Trace, "B")

--- a/plugin/src/NH/Logger.h
+++ b/plugin/src/NH/Logger.h
@@ -48,6 +48,8 @@ namespace NH
         Union::Array<ILoggerAdapter*> m_Adapters;
 
     public:
+        friend class LoggerFactory;
+
         explicit Logger(const String& name) : m_LoggerName(name) {};
 
         explicit Logger(const String& name, Union::Array<ILoggerAdapter*> adapters) : m_LoggerName(name), m_Adapters(adapters) {};


### PR DESCRIPTION
Loggers with the same name could be created multiple times, causing leaks.
I added a check in `LoggerFactory::Create` and if the logger exists, it returns the existing pointer.
